### PR TITLE
Batch mode for multiple URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,45 @@ dit run login.html
 # With probabilities
 dit run https://github.com/login --proba
 
+# Process multiple URLs from a file (one URL per line)
+dit run --list urls.txt
+
+# Batch processing with probabilities
+dit run --list urls.txt --proba
+
 # Train a model
 dit train model.json --data-folder data
 
 # Evaluate model accuracy
 dit evaluate --data-folder data
+
+#### Batch Processing
+
+Process multiple URLs from a file for efficient batch classification:
+
+```bash
+# Create a file with URLs (one per line)
+cat > urls.txt << EOF
+# Comments are supported
+https://github.com/login
+https://github.com/signup
+https://github.com/password_reset
+EOF
+
+# Process all URLs and stream results as JSON lines
+dit run --list urls.txt --silent
+
+# Pretty print with jq
+dit run --list urls.txt --silent | jq '.'
+
+# Extract just URLs and page types
+dit run --list urls.txt --silent | jq -r '"\(.url) -> \(.page.type)"'
+
+# Filter specific page types
+dit run --list urls.txt --silent | jq 'select(.page.type == "login")'
+```
+
+**Output format**: Results are streamed as [JSON Lines](https://jsonlines.org/) (one JSON object per line), making it easy to process with standard Unix tools.
 ```
 
 ## Page Types

--- a/cmd/dit/main.go
+++ b/cmd/dit/main.go
@@ -378,6 +378,117 @@ func fetchHTML(target string) (string, error) {
 	return string(data), nil
 }
 
+func processURLList(c *dit.Classifier, listFile string, proba bool, threshold float64) error {
+	//Read the file
+	data, err := os.ReadFile(listFile)
+	if err != nil {
+		return fmt.Errorf("read list file: %w", err)
+	}
+
+	//Parse urls from the file(one per line)
+	lines := strings.Split(string(data), "\n")
+	urls := make([]string, 0)
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		urls = append(urls, line)
+	}
+
+	if len(urls) == 0 {
+		return fmt.Errorf("no URLs found in the list file %s", listFile)
+	}
+
+	slog.Info("Processing URLs","count",len(urls), "source", listFile)
+
+	//Process each URL
+	for _, url := range urls {
+		slog.Debug("Processing URL", "url", url)
+		htmlContent, err := fetchHTML(url)
+		if err != nil {
+			slog.Warn("Failed to fetch HTML", "url", url, "error", err)
+			result := map[string]interface{}{
+				"url": url,
+				"error": err.Error(),
+			}
+			output, _ := json.Marshal(result)
+			fmt.Println(string(output))
+			continue
+		}
+		
+		// Classify the HTML
+		start := time.Now()
+		if proba {
+			// Try page classification first
+			pageResult, pageErr := c.ExtractPageTypeProba(htmlContent, threshold)
+			if pageErr == nil {
+				slog.Debug("Page classification completed", "url", url, "duration", time.Since(start))
+				result := map[string]interface{}{
+					"url":  url,
+					"page": pageResult,
+				}
+				output, _ := json.Marshal(result)
+				fmt.Println(string(output))
+			} else {
+				// Fall back to form-only classification
+				formResults, formErr := c.ExtractFormsProba(htmlContent, threshold)
+				if formErr != nil {
+					slog.Warn("Classification failed", "url", url, "error", formErr)
+					result := map[string]interface{}{
+						"url":   url,
+						"error": formErr.Error(),
+					}
+					output, _ := json.Marshal(result)
+					fmt.Println(string(output))
+				} else {
+					slog.Debug("Form classification completed", "url", url, "forms", len(formResults), "duration", time.Since(start))
+					result := map[string]interface{}{
+						"url":   url,
+						"forms": formResults,
+					}
+					output, _ := json.Marshal(result)
+					fmt.Println(string(output))
+				}
+			}
+		} else {
+			// Try page classification first
+			pageResult, pageErr := c.ExtractPageType(htmlContent)
+			if pageErr == nil {
+				slog.Debug("Page classification completed", "url", url, "duration", time.Since(start))
+				result := map[string]interface{}{
+					"url":  url,
+					"page": pageResult,
+				}
+				output, _ := json.Marshal(result)
+				fmt.Println(string(output))
+			} else {
+				// Fall back to form-only classification
+				formResults, formErr := c.ExtractForms(htmlContent)
+				if formErr != nil {
+					slog.Warn("Classification failed", "url", url, "error", formErr)
+					result := map[string]interface{}{
+						"url":   url,
+						"error": formErr.Error(),
+					}
+					output, _ := json.Marshal(result)
+					fmt.Println(string(output))
+				} else {
+					slog.Debug("Form classification completed", "url", url, "forms", len(formResults), "duration", time.Since(start))
+					result := map[string]interface{}{
+						"url":   url,
+						"forms": formResults,
+					}
+					output, _ := json.Marshal(result)
+					fmt.Println(string(output))
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
 func main() {
 	rootCmd := &cobra.Command{
 		Use:     "dît",
@@ -427,17 +538,18 @@ func main() {
 	var runModelPath string
 	var runThreshold float64
 	var runProba bool
+	var runListFile string
 	runCmd := &cobra.Command{
 		Use:   "run <url-or-file>",
 		Short: "Classify page type and forms in a URL or HTML file",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		Example: `  dit run https://github.com/login
   dit run login.html
   dit run https://github.com/login --proba
   dit run https://github.com/login --proba --threshold 0.1
-  dit run https://github.com/login --model custom.json`,
+  dit run https://github.com/login --model custom.json
+  dit run --list urls.txt`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			target := args[0]
 
 			start := time.Now()
 			c, err := loadOrDownloadModel(runModelPath)
@@ -445,6 +557,17 @@ func main() {
 				return err
 			}
 			slog.Debug("Model loaded", "duration", time.Since(start))
+
+			//Check if list flag is provided
+			if runListFile != "" {
+				return processURLList(c, runListFile, runProba, runThreshold)
+			}
+
+			//Handle single target
+			if len(args) == 0 {
+				return fmt.Errorf("either provide a URL/file or use --list flag")
+			}
+			target := args[0]
 
 			slog.Debug("Fetching HTML", "target", target)
 			htmlContent, err := fetchHTML(target)
@@ -501,6 +624,7 @@ func main() {
 	runCmd.Flags().StringVar(&runModelPath, "model", "", "Path to model file (default: auto-detect or download)")
 	runCmd.Flags().Float64Var(&runThreshold, "threshold", 0.05, "Minimum probability threshold")
 	runCmd.Flags().BoolVar(&runProba, "proba", false, "Show probabilities")
+	runCmd.Flags().StringVar(&runListFile, "list", "", "File containing a list of URLs to classify")
 
 	var evalDataFolder string
 	var evalCVFolds int


### PR DESCRIPTION
Fixes #4 

## Type
- [x] **feat** (New capability)
- [ ] **fix** (Bug fix)
- [ ] **test** (Test-only changes)
- [ ] **chore** (Refactor, docs, or cleanup)

## Description
Added `--list` flag to `dit run` command for batch processing of multiple URLs from a file. This implements issue #10 and enables efficient classification of many URLs without requiring multiple command invocations.

**Changes:**
- Added `--list` flag that accepts a filename containing URLs (one per line)
- Implemented `processURLList()` function to read, parse, and process URLs from file
- Updated command to accept 0-1 arguments (previously required exactly 1)
- Results are streamed as JSON Lines format for easy processing with standard Unix tools
- Supports comments (lines starting with `#`) and empty lines in URL files
- Graceful error handling: continues processing remaining URLs if one fails
- Maintains backward compatibility with single URL mode
- Updated README with batch processing documentation and usage examples

**Technical Details:**
- Model is loaded once and reused for all URLs (efficient)
- Each result is output immediately (streaming, not buffered)
- Errors are captured in JSON output but don't halt processing
- Output format: JSON Lines (one compact JSON object per line)

## Proof of Work (REQUIRED)

*Batch mode for multiple urls working - Listed in a file*

![WhatsApp Image 2026-02-08 at 17 03 20 (1)](https://github.com/user-attachments/assets/19244b6f-aedc-48a9-a8f6-d5dfd07ddd0f)


*Single Url working*

![WhatsApp Image 2026-02-08 at 17 03 20](https://github.com/user-attachments/assets/e4dfe898-1e21-44a2-8262-38902e9a9815)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added batch processing capability: process multiple URLs from a file using `dit run --list urls.txt`
  * Introduced `--proba` flag for probability-based classification in batch mode
  * Streaming JSON Lines output format (one JSON object per line) compatible with Unix tools
  * Enhanced error handling: continues processing remaining URLs if one fails

<!-- end of auto-generated comment: release notes by coderabbit.ai -->